### PR TITLE
Add Docker support and simple web interface

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Run stage
+FROM node:20-slim
+WORKDIR /app
+COPY --from=build /app /app
+EXPOSE 8800
+ENV PORT=8800
+CMD ["node", "dist/webui/server.js"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ See the [example config](./example-embed.conf) on how to configure an external d
 
    The `-g` option is for installing `patreon-dl` globally and have the CLI executable added to the PATH. Depending on your usage, you might not need this.
 
+## Docker & Web UI
+
+The repository includes a minimal web interface for starting downloads and viewing log output. To build and run it in Docker:
+
+```
+docker build -t patreon-dl .
+docker run -p 8800:8800 patreon-dl
+```
+
+Open `http://localhost:8800` in your browser to configure the download and see logs. Use environment variable `PORT` to change the port if another `880X` port is required.
+
 ## CLI usage
 
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,7 +134,8 @@ export default tslint.config(
             "docs",
             "**/node_modules",
             "bin",
-            "test"
+            "test",
+            "src/webui/public"
         ],
     },
 );

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "npm run build:core && npm run build:web",
-    "build:core": "rm -rf dist && npx tsc -p tsconfig.json",
+    "build:core": "rm -rf dist && npx tsc -p tsconfig.json && cp -r src/webui/public dist/webui",
     "lint": "npx eslint ./src",
     "lint:fix": "npx eslint ./src --fix",
     "build:web": "vite build",
-    "doc": "npx typedoc"
+    "doc": "npx typedoc",
+    "start:webui": "node dist/webui/server.js"
   },
   "bin": {
     "patreon-dl": "./bin/patreon-dl.js",

--- a/src/webui/public/index.html
+++ b/src/webui/public/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>patreon-dl Web UI</title>
+</head>
+<body>
+  <form id="configForm">
+    <div>
+      <label>Target URL: <input id="targetUrl" required></label>
+    </div>
+    <div>
+      <label>Cookie: <input id="cookie" required></label>
+    </div>
+    <div>
+      <label>Output Directory: <input id="outDir" value="./downloads"></label>
+    </div>
+    <button type="submit">Start Download</button>
+  </form>
+  <pre id="logs" style="height:300px; overflow:auto; border:1px solid #ccc;"></pre>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/src/webui/public/main.js
+++ b/src/webui/public/main.js
@@ -1,0 +1,22 @@
+document.getElementById('configForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const targetUrl = document.getElementById('targetUrl').value;
+  const cookie = document.getElementById('cookie').value;
+  const outDir = document.getElementById('outDir').value;
+  await fetch('/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ targetUrl, cookie, outDir })
+  });
+  const logs = document.getElementById('logs');
+  logs.textContent = '';
+  const source = new EventSource('/logs');
+  source.onmessage = (e) => {
+    if (e.data === '##END##') {
+      source.close();
+    } else {
+      logs.textContent += e.data + '\n';
+      logs.scrollTop = logs.scrollHeight;
+    }
+  };
+});

--- a/src/webui/server.ts
+++ b/src/webui/server.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import path from 'path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import fs from 'fs';
+import { tmpdir } from 'os';
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.resolve(import.meta.dirname, 'public')));
+
+let currentProcess: ChildProcessWithoutNullStreams | null = null;
+const clients: express.Response[] = [];
+
+app.post('/start', (req, res) => {
+  if (currentProcess) {
+    res.status(409).json({ error: 'Download already running' });
+    return;
+  }
+
+  const { targetUrl, cookie, outDir } = req.body as {
+    targetUrl?: string;
+    cookie?: string;
+    outDir?: string;
+  };
+
+  if (!targetUrl || !cookie) {
+    res.status(400).json({ error: 'targetUrl and cookie required' });
+    return;
+  }
+
+  const confPath = path.join(tmpdir(), 'webui.conf');
+  const conf = `[downloader]\ntarget.url = ${targetUrl}\ncookie = ${cookie}\n\n[output]\nout.dir = ${outDir || '.'}\n`;
+  fs.writeFileSync(confPath, conf);
+
+  const cliPath = path.resolve(import.meta.dirname, '../../bin/patreon-dl.js');
+  currentProcess = spawn('node', [cliPath, '-c', confPath]);
+
+  currentProcess.stdout.on('data', (data) => {
+    const message = data.toString();
+    clients.forEach((client) => client.write(`data: ${message.replace(/\n/g, '\\n')}\n\n`));
+  });
+  currentProcess.stderr.on('data', (data) => {
+    const message = data.toString();
+    clients.forEach((client) => client.write(`data: ${message.replace(/\n/g, '\\n')}\n\n`));
+  });
+  currentProcess.on('close', () => {
+    clients.forEach((client) => client.write('data: ##END##\n\n'));
+    currentProcess = null;
+  });
+
+  res.json({ status: 'started' });
+});
+
+app.get('/logs', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  });
+  res.write('\n');
+  clients.push(res);
+  req.on('close', () => {
+    const index = clients.indexOf(res);
+    if (index !== -1) {
+      clients.splice(index, 1);
+    }
+  });
+});
+
+const port = Number(process.env.PORT) || 8800;
+app.listen(port, () => {
+  console.log(`Web UI listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add Dockerfile and scripts to build and run patreon-dl with a web UI on port 8800
- provide minimal HTML interface to configure downloads and stream logs
- document Docker usage and web UI in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac2f5176148325a96a06d56f42deaa